### PR TITLE
Add surprise gift reveal flow for birthday wishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# Custom_birthday
+# Custom Birthday Wishes
+
+A single-page web app that wraps a personalised birthday wish inside a playful gift reveal. Enter the birthday person's name, hand them the screen, and let them tap the present to see a heartfelt message made just for them.
+
+## Getting started
+
+1. Install dependencies (none required, everything runs in the browser).
+2. Open `index.html` in your favourite browser.
+3. Type a name and click **Create surprise**. The page will swap to a gift image ready for the birthday person to tap and reveal their message.
+
+## Features
+
+- A curated set of celebratory templates that automatically include the name you enter.
+- Smart shuffling that avoids repeating the same template back-to-back.
+- Copy-to-clipboard shortcut for quick sharing after the surprise is revealed.
+- Responsive, glassmorphism-inspired layout that looks great on desktop and mobile.
+
+## Development
+
+The project is entirely static, so you can use any local web server. For example:
+
+```bash
+python3 -m http.server
+```
+
+Then open your browser at <http://localhost:8000>.

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,264 @@
+:root {
+    color-scheme: dark;
+    --bg: radial-gradient(circle at top, #253457, #0f1628 55%, #070b16 100%);
+    --panel: rgba(18, 26, 43, 0.78);
+    --card: rgba(20, 28, 46, 0.85);
+    --accent: #64b5ff;
+    --accent-strong: #2f7bff;
+    --text: #f8fbff;
+    --muted: #c7d7f6;
+    --error: #ff7a99;
+    --radius-lg: 28px;
+    --radius-md: 18px;
+    --radius-sm: 12px;
+    --shadow-lg: 0 32px 70px rgba(4, 10, 25, 0.42);
+    --shadow-sm: 0 18px 36px rgba(8, 16, 36, 0.28);
+    font-size: 16px;
+}
+
+body {
+    min-height: 100vh;
+    margin: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: clamp(1.5rem, 3vw, 3rem);
+    background: var(--bg);
+    font-family: 'Inter', sans-serif;
+    color: var(--text);
+}
+
+.app {
+    width: min(940px, 100%);
+    display: grid;
+    background: var(--panel);
+    padding: clamp(2.5rem, 4vw, 3.75rem);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    backdrop-filter: blur(18px);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.panel {
+    display: grid;
+    gap: clamp(1.75rem, 3vw, 2.75rem);
+}
+
+.panel[hidden] {
+    display: none !important;
+}
+
+.hero {
+    display: grid;
+    gap: 0.75rem;
+    max-width: 56ch;
+}
+
+.hero h1 {
+    font-size: clamp(2.35rem, 5vw, 3.5rem);
+    line-height: 1.1;
+    margin: 0;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.6);
+    margin: 0;
+}
+
+.lead {
+    font-size: clamp(1.05rem, 2.5vw, 1.2rem);
+    color: var(--muted);
+    margin: 0;
+}
+
+.wish-form {
+    display: grid;
+    gap: 1rem;
+    background: var(--card);
+    padding: clamp(1.75rem, 3vw, 2.6rem);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.form-label {
+    font-weight: 600;
+    font-size: 1rem;
+}
+
+.input-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.input-group input {
+    flex: 1 1 240px;
+    padding: 0.9rem 1.15rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(9, 15, 30, 0.65);
+    color: var(--text);
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input-group input::placeholder {
+    color: rgba(255, 255, 255, 0.45);
+}
+
+.input-group input:focus {
+    outline: none;
+    border-color: rgba(100, 181, 255, 0.9);
+    box-shadow: 0 0 0 4px rgba(100, 181, 255, 0.25);
+}
+
+.primary-btn,
+.secondary-btn {
+    cursor: pointer;
+    font-weight: 600;
+    border-radius: var(--radius-sm);
+    border: none;
+    padding: 0.95rem 1.7rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.primary-btn {
+    background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+    color: var(--text);
+    box-shadow: var(--shadow-sm);
+    flex: 0 0 auto;
+}
+
+.primary-btn:hover,
+.primary-btn:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 22px 44px rgba(47, 123, 255, 0.45);
+}
+
+.secondary-btn {
+    background: rgba(255, 255, 255, 0.12);
+    color: var(--text);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.secondary-btn:hover,
+.secondary-btn:focus-visible {
+    transform: translateY(-1px);
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.form-help {
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.65);
+    margin: 0;
+}
+
+.form-error {
+    font-size: 0.95rem;
+    color: var(--error);
+    margin: 0;
+}
+
+.panel--gift,
+.panel--message {
+    place-items: center;
+    text-align: center;
+}
+
+.gift-card {
+    display: grid;
+    gap: 1.75rem;
+    max-width: 460px;
+    background: var(--card);
+    padding: clamp(1.9rem, 3vw, 2.75rem);
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow: var(--shadow-sm);
+}
+
+.gift-card p {
+    margin: 0;
+    font-size: 1.1rem;
+}
+
+.gift-intro {
+    font-weight: 600;
+}
+
+.gift-button {
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    border-radius: 26px;
+    overflow: hidden;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    box-shadow: 0 18px 44px rgba(0, 0, 0, 0.4);
+}
+
+.gift-button img {
+    display: block;
+    width: min(320px, 60vw);
+    height: auto;
+}
+
+.gift-button:hover,
+.gift-button:focus-visible {
+    transform: scale(1.03);
+    box-shadow: 0 24px 56px rgba(0, 0, 0, 0.48);
+}
+
+.gift-hint {
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.65);
+}
+
+.wish-card {
+    display: grid;
+    gap: 1.75rem;
+    max-width: 520px;
+    background: var(--card);
+    padding: clamp(2rem, 4vw, 2.9rem);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-sm);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.wish-header h2 {
+    margin: 0;
+    font-size: clamp(1.6rem, 4vw, 2.1rem);
+}
+
+.message {
+    margin: 0;
+    font-size: clamp(1.15rem, 2.6vw, 1.35rem);
+    line-height: 1.6;
+}
+
+.actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: center;
+}
+
+@media (max-width: 640px) {
+    body {
+        padding: 1.5rem;
+    }
+
+    .app {
+        padding: 2rem;
+        border-radius: 22px;
+    }
+
+    .panel {
+        gap: 1.5rem;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -3,12 +3,57 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Click on the gift</title>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans&display=swap">
-    <link rel="stylesheet" href="./css/style.css">
+    <title>Custom Birthday Wishes</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="./css/reset.css">
+    <link rel="stylesheet" href="./css/style.css">
 </head>
 <body>
-    
+    <main class="app" role="main">
+        <section class="panel panel--form" data-screen="form">
+            <header class="hero">
+                <p class="eyebrow">Birthday wish builder</p>
+                <h1>Wrap their wish in a surprise</h1>
+                <p class="lead">Type the birthday person's name, hand them the screen, and let them tap the gift to reveal a personalised message.</p>
+            </header>
+
+            <form class="wish-form" aria-label="Birthday message generator" novalidate>
+                <label for="birthday-name" class="form-label">Who is celebrating today?</label>
+                <div class="input-group">
+                    <input id="birthday-name" name="name" type="text" placeholder="e.g. Priya" autocomplete="off" maxlength="40" required aria-describedby="name-help">
+                    <button type="submit" class="primary-btn">Create surprise</button>
+                </div>
+                <p id="name-help" class="form-help">We'll use their name inside the wish so it feels written just for them.</p>
+                <p class="form-error" role="alert" hidden>Please add a name so we can personalise the wish.</p>
+            </form>
+        </section>
+
+        <section class="panel panel--gift" data-screen="gift" hidden>
+            <div class="gift-card">
+                <p class="gift-intro">Hey <span data-recipient>friend</span>, tap the present to open your birthday surprise! 🎁</p>
+                <button type="button" class="gift-button" data-open-gift>
+                    <img src="./img/gift.png" alt="Wrapped gift ready to be opened">
+                </button>
+                <p class="gift-hint">(Tap the present when you're ready)</p>
+            </div>
+        </section>
+
+        <section class="panel panel--message" data-screen="message" hidden>
+            <article class="wish-card">
+                <header class="wish-header">
+                    <h2>Birthday wish for <span data-recipient>you</span></h2>
+                </header>
+                <p class="message" data-message></p>
+                <div class="actions">
+                    <button type="button" class="primary-btn" data-copy>Copy wish</button>
+                    <button type="button" class="secondary-btn" data-start-over>Make another</button>
+                </div>
+            </article>
+        </section>
+    </main>
+
+    <script src="./js/app.js" defer></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,160 @@
+const templates = [
+    (name) => `Happy Birthday, ${name}! May today be packed with bright laughter, joyful memories, and the people who love you most.`,
+    (name) => `${name}, here's to a new year of adventures, cosy nights in, and the kind of happiness that sticks around.`,
+    (name) => `Celebrating you today, ${name}! I hope the next twelve months bring easy smiles, little wins, and big, bold dreams.`,
+    (name) => `Happy Birthday, ${name}! You make every space warmer just by being there—cheers to another unforgettable year.`,
+    (name) => `${name}, wishing you cake, confetti, and those heart-hugging moments that remind you how loved you are.`,
+    (name) => `It's your day, ${name}! May it overflow with people who cherish you and stories you'll be telling for ages.`,
+    (name) => `To the wonderful ${name}: keep shining, keep laughing, and keep being exactly who you are.`,
+    (name) => `Have the happiest birthday, ${name}! Here's to restful mornings, thrilling adventures, and everything in between.`,
+    (name) => `${name}, sending you birthday magic, favourite songs on repeat, and a year that fits you just right.`
+];
+
+const screens = {
+    form: document.querySelector('[data-screen="form"]'),
+    gift: document.querySelector('[data-screen="gift"]'),
+    message: document.querySelector('[data-screen="message"]')
+};
+
+const form = document.querySelector('.wish-form');
+const nameInput = document.querySelector('#birthday-name');
+const recipientFields = document.querySelectorAll('[data-recipient]');
+const messageOutput = document.querySelector('[data-message]');
+const giftButton = document.querySelector('[data-open-gift]');
+const copyButton = document.querySelector('[data-copy]');
+const startOverButton = document.querySelector('[data-start-over]');
+const errorMessage = document.querySelector('.form-error');
+
+let lastTemplateIndex = null;
+let currentMessage = '';
+
+const capitaliseName = (value) =>
+    value
+        .trim()
+        .replace(/\s+/g, ' ')
+        .split(' ')
+        .filter(Boolean)
+        .map((chunk) => chunk.charAt(0).toUpperCase() + chunk.slice(1).toLowerCase())
+        .join(' ');
+
+const pickTemplate = () => {
+    if (templates.length === 1) {
+        return { template: templates[0], index: 0 };
+    }
+
+    let index = Math.floor(Math.random() * templates.length);
+    while (index === lastTemplateIndex) {
+        index = Math.floor(Math.random() * templates.length);
+    }
+
+    return { template: templates[index], index };
+};
+
+const setRecipient = (name) => {
+    recipientFields.forEach((field) => {
+        field.textContent = name;
+    });
+};
+
+const setMessage = (text) => {
+    messageOutput.textContent = text;
+};
+
+const handleError = (hasError) => {
+    if (hasError) {
+        errorMessage.hidden = false;
+        nameInput.setAttribute('aria-invalid', 'true');
+    } else {
+        errorMessage.hidden = true;
+        nameInput.removeAttribute('aria-invalid');
+    }
+};
+
+const showScreen = (target) => {
+    Object.entries(screens).forEach(([key, section]) => {
+        if (key === target) {
+            section.hidden = false;
+        } else {
+            section.hidden = true;
+        }
+    });
+};
+
+const generateMessage = () => {
+    const cleaned = capitaliseName(nameInput.value);
+
+    if (!cleaned) {
+        handleError(true);
+        nameInput.focus();
+        return false;
+    }
+
+    handleError(false);
+
+    const { template, index } = pickTemplate();
+    lastTemplateIndex = index;
+
+    currentMessage = template(cleaned);
+
+    setRecipient(cleaned);
+    setMessage('');
+
+    return true;
+};
+
+form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    if (generateMessage()) {
+        showScreen('gift');
+        giftButton.focus();
+    }
+});
+
+nameInput.addEventListener('input', () => {
+    if (nameInput.value.trim()) {
+        handleError(false);
+    }
+});
+
+giftButton.addEventListener('click', () => {
+    if (!currentMessage) {
+        return;
+    }
+
+    setMessage(currentMessage);
+    showScreen('message');
+    copyButton.focus();
+});
+
+copyButton.addEventListener('click', async () => {
+    if (!currentMessage) {
+        copyButton.blur();
+        return;
+    }
+
+    const originalText = copyButton.textContent;
+
+    try {
+        await navigator.clipboard.writeText(currentMessage);
+        copyButton.textContent = 'Copied!';
+        copyButton.disabled = true;
+        setTimeout(() => {
+            copyButton.textContent = originalText;
+            copyButton.disabled = false;
+        }, 1500);
+    } catch (error) {
+        copyButton.textContent = 'Press Ctrl+C to copy';
+        setTimeout(() => {
+            copyButton.textContent = originalText;
+        }, 2000);
+    }
+});
+
+startOverButton.addEventListener('click', () => {
+    currentMessage = '';
+    nameInput.value = '';
+    setMessage('');
+    handleError(false);
+    showScreen('form');
+    nameInput.focus();
+});


### PR DESCRIPTION
## Summary
- rework the landing experience into a three-step flow with a surprise gift reveal and personalised message screen
- update the styling to support the new panels and refine the glassmorphism presentation
- refresh the README to explain the gift interaction and clipboard sharing

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dc5a9b469883279bcec81b83d0aa84